### PR TITLE
feat(api): allow user to pass in transport to be wrapped

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Retries are defined at the transport layer.
 ```python
 import httpx
 
-from httpx_retry import HTTPRetryTransport, RetryPolicy
+from httpx_retry import RetryTransport, RetryPolicy
 
 exponential_retry = (
     RetryPolicy()
@@ -24,7 +24,7 @@ exponential_retry = (
       .with_retry_on(lambda code: code >= 500)
 )
 
-client = httpx.Client(transport=HTTPRetryTransport(policy=exponential_retry))
+client = httpx.Client(transport=RetryTransport(policy=exponential_retry))
 res = client.get("https://example.com")
 ```
 

--- a/src/httpx_retry/__init__.py
+++ b/src/httpx_retry/__init__.py
@@ -1,4 +1,4 @@
 from .policies import RetryPolicy
-from .transports import AsyncHTTPRetryTransport, HTTPRetryTransport
+from .transports import AsyncRetryTransport, RetryTransport
 
-__all__ = ["HTTPRetryTransport", "AsyncHTTPRetryTransport", "RetryPolicy"]
+__all__ = ["RetryTransport", "AsyncRetryTransport", "RetryPolicy"]

--- a/src/httpx_retry/executor.py
+++ b/src/httpx_retry/executor.py
@@ -4,12 +4,13 @@ from typing import Any, Awaitable, Callable, Optional
 
 from httpx import Response
 
+from .policies import RetryPolicy
 from .policies.base import BaseRetryPolicy
 
 
 class RetryExecutor:
-    def __init__(self, policy: BaseRetryPolicy) -> None:
-        self.policy = policy
+    def __init__(self, policy: Optional[BaseRetryPolicy] = None) -> None:
+        self.policy = policy or RetryPolicy()
 
     def execute(
         self, func: Callable[..., Response], *args: Any, **kwargs: Any
@@ -54,8 +55,8 @@ class RetryExecutor:
 
 
 class AsyncRetryExecutor:
-    def __init__(self, policy: BaseRetryPolicy) -> None:
-        self.policy = policy
+    def __init__(self, policy: Optional[BaseRetryPolicy] = None) -> None:
+        self.policy = policy or RetryPolicy()
 
     async def execute(
         self,

--- a/src/httpx_retry/transports.py
+++ b/src/httpx_retry/transports.py
@@ -1,30 +1,43 @@
-from typing import Any
+from typing import Optional
 
-from httpx import AsyncHTTPTransport, HTTPTransport, Request, Response
+from httpx import (
+    AsyncBaseTransport,
+    AsyncHTTPTransport,
+    BaseTransport,
+    HTTPTransport,
+    Request,
+    Response,
+)
 
 from .executor import AsyncRetryExecutor, RetryExecutor
 from .policies.base import BaseRetryPolicy
 
-__all__ = ["HTTPRetryTransport", "AsyncHTTPRetryTransport"]
+__all__ = ["RetryTransport", "AsyncRetryTransport"]
 
 
-class HTTPRetryTransport(HTTPTransport):
-    def __init__(self, policy: BaseRetryPolicy, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
+class RetryTransport(BaseTransport):
+    def __init__(
+        self,
+        transport: Optional[BaseTransport] = None,
+        policy: Optional[BaseRetryPolicy] = None,
+    ) -> None:
+        self.transport = transport or HTTPTransport()
         self.executor = RetryExecutor(policy)
 
     def handle_request(self, request: Request) -> Response:
-        return self.executor.execute(
-            lambda: super(HTTPRetryTransport, self).handle_request(request)
-        )
+        return self.executor.execute(lambda: self.transport.handle_request(request))
 
 
-class AsyncHTTPRetryTransport(AsyncHTTPTransport):
-    def __init__(self, policy: BaseRetryPolicy, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
+class AsyncRetryTransport(AsyncBaseTransport):
+    def __init__(
+        self,
+        transport: Optional[AsyncBaseTransport] = None,
+        policy: Optional[BaseRetryPolicy] = None,
+    ) -> None:
+        self.transport = transport or AsyncHTTPTransport()
         self.executor = AsyncRetryExecutor(policy)
 
     async def handle_async_request(self, request: Request) -> Response:
         return await self.executor.execute(
-            lambda: super(AsyncHTTPRetryTransport, self).handle_async_request(request)
+            lambda: self.transport.handle_async_request(request)
         )

--- a/tests/test_adaptive_retry.py
+++ b/tests/test_adaptive_retry.py
@@ -10,7 +10,7 @@ import httpx
 import pytest
 import respx
 
-from httpx_retry import AsyncHTTPRetryTransport, HTTPRetryTransport, RetryPolicy
+from httpx_retry import AsyncRetryTransport, RetryPolicy, RetryTransport
 
 
 def adaptive_adjustment(
@@ -44,7 +44,7 @@ def test_adaptive_retry_with_retry_after(respx_mock: respx.MockRouter):
     )
 
     start = time.monotonic()
-    with httpx.Client(transport=HTTPRetryTransport(policy=adaptive_policy)) as client:
+    with httpx.Client(transport=RetryTransport(policy=adaptive_policy)) as client:
         response = client.get("https://example.com")
         assert response.status_code == 200
     end = time.monotonic()
@@ -75,7 +75,7 @@ async def test_async_adaptive_retry_with_retry_after(respx_mock: respx.MockRoute
 
     start = time.monotonic()
     async with httpx.AsyncClient(
-        transport=AsyncHTTPRetryTransport(policy=adaptive_policy)
+        transport=AsyncRetryTransport(policy=adaptive_policy)
     ) as client:
         response = await client.get("https://example.com")
         assert response.status_code == 200

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -11,7 +11,7 @@ import httpx
 import pytest
 import respx
 
-from httpx_retry import AsyncHTTPRetryTransport, HTTPRetryTransport
+from httpx_retry import AsyncRetryTransport, RetryTransport
 from httpx_retry.policies.base import BaseRetryPolicy
 
 
@@ -84,7 +84,7 @@ def test_circuit_breaker(respx_mock: respx.MockRouter):
         CircuitBreakerPolicy().with_failure_threshold(3).with_recovery_timeout(60)
     )
 
-    with httpx.Client(transport=HTTPRetryTransport(policy=circuit_breaker)) as client:  # noqa: SIM117
+    with httpx.Client(transport=RetryTransport(policy=circuit_breaker)) as client:  # noqa: SIM117
         with contextlib.suppress(Exception):
             client.get("https://example.com")
 
@@ -107,7 +107,7 @@ async def test_async_circuit_breaker(respx_mock: respx.MockRouter):
     )
 
     async with httpx.AsyncClient(
-        transport=AsyncHTTPRetryTransport(policy=circuit_breaker)
+        transport=AsyncRetryTransport(policy=circuit_breaker)
     ) as client:
         with contextlib.suppress(Exception):
             await client.get("https://example.com")

--- a/tests/test_exponential_backoff.py
+++ b/tests/test_exponential_backoff.py
@@ -9,7 +9,7 @@ import httpx
 import pytest
 import respx
 
-from httpx_retry import AsyncHTTPRetryTransport, HTTPRetryTransport, RetryPolicy
+from httpx_retry import AsyncRetryTransport, RetryPolicy, RetryTransport
 
 
 @respx.mock()
@@ -26,7 +26,7 @@ def test_exponential_backoff(respx_mock: respx.MockRouter):
     )
 
     start = time.monotonic()
-    with httpx.Client(transport=HTTPRetryTransport(policy=exponential_retry)) as client:
+    with httpx.Client(transport=RetryTransport(policy=exponential_retry)) as client:
         res = client.get("https://example.com")
         assert res.status_code == 200
     end = time.monotonic()
@@ -53,7 +53,7 @@ async def test_async_exponential_backoff(respx_mock: respx.MockRouter):
 
     start = time.monotonic()
     async with httpx.AsyncClient(
-        transport=AsyncHTTPRetryTransport(policy=exponential_retry)
+        transport=AsyncRetryTransport(policy=exponential_retry)
     ) as client:
         res = await client.get("https://example.com")
         assert res.status_code == 200

--- a/tests/test_fibonacci_backoff.py
+++ b/tests/test_fibonacci_backoff.py
@@ -10,7 +10,7 @@ import httpx
 import pytest
 import respx
 
-from httpx_retry import AsyncHTTPRetryTransport, HTTPRetryTransport, RetryPolicy
+from httpx_retry import AsyncRetryTransport, RetryPolicy, RetryTransport
 
 
 def fibonacci_delay(initial_delay: float) -> Callable[[int], float]:
@@ -35,7 +35,7 @@ def test_fibonacci_backoff(respx_mock: respx.MockRouter):
     fibonacci_retry = RetryPolicy().with_attempts(3).with_delay(fibonacci_delay(0.1))
 
     start = time.monotonic()
-    with httpx.Client(transport=HTTPRetryTransport(policy=fibonacci_retry)) as client:
+    with httpx.Client(transport=RetryTransport(policy=fibonacci_retry)) as client:
         res = client.get("https://example.com")
         assert res.status_code == 200
     end = time.monotonic()
@@ -60,7 +60,7 @@ async def test_async_fibonacci_backoff(respx_mock: respx.MockRouter):
 
     start = time.monotonic()
     async with httpx.AsyncClient(
-        transport=AsyncHTTPRetryTransport(policy=fibonacci_retry)
+        transport=AsyncRetryTransport(policy=fibonacci_retry)
     ) as client:
         res = await client.get("https://example.com")
         assert res.status_code == 200

--- a/tests/test_fixed_delay.py
+++ b/tests/test_fixed_delay.py
@@ -7,8 +7,7 @@ import httpx
 import pytest
 import respx
 
-from httpx_retry import HTTPRetryTransport, RetryPolicy
-from httpx_retry.transports import AsyncHTTPRetryTransport
+from httpx_retry import AsyncRetryTransport, RetryPolicy, RetryTransport
 
 
 @respx.mock()
@@ -22,7 +21,7 @@ def test_fixed_delay(respx_mock: respx.MockRouter):
 
     immediate_retry = RetryPolicy().with_attempts(3).with_delay(0.5)
 
-    with httpx.Client(transport=HTTPRetryTransport(policy=immediate_retry)) as client:
+    with httpx.Client(transport=RetryTransport(policy=immediate_retry)) as client:
         res = client.get("https://example.com")
         assert res.status_code == 200
 
@@ -42,7 +41,7 @@ async def test_async_fixed_delay(respx_mock: respx.MockRouter):
     immediate_retry = RetryPolicy().with_attempts(3).with_delay(0.5)
 
     async with httpx.AsyncClient(
-        transport=AsyncHTTPRetryTransport(policy=immediate_retry)
+        transport=AsyncRetryTransport(policy=immediate_retry)
     ) as client:
         res = await client.get("https://example.com")
         assert res.status_code == 200

--- a/tests/test_immediate_retry.py
+++ b/tests/test_immediate_retry.py
@@ -7,8 +7,7 @@ import httpx
 import pytest
 import respx
 
-from httpx_retry import HTTPRetryTransport, RetryPolicy
-from httpx_retry.transports import AsyncHTTPRetryTransport
+from httpx_retry import AsyncRetryTransport, RetryPolicy, RetryTransport
 
 
 @respx.mock()
@@ -22,7 +21,7 @@ def test_immediate_retry(respx_mock: respx.MockRouter):
 
     immediate_retry = RetryPolicy().with_attempts(3).with_delay(0)
 
-    with httpx.Client(transport=HTTPRetryTransport(policy=immediate_retry)) as client:
+    with httpx.Client(transport=RetryTransport(policy=immediate_retry)) as client:
         res = client.get("https://example.com")
         assert res.status_code == 200
 
@@ -42,7 +41,7 @@ async def test_async_immediate_retry(respx_mock: respx.MockRouter):
     immediate_retry = RetryPolicy().with_attempts(3).with_delay(0)
 
     async with httpx.AsyncClient(
-        transport=AsyncHTTPRetryTransport(policy=immediate_retry)
+        transport=AsyncRetryTransport(policy=immediate_retry)
     ) as client:
         res = await client.get("https://example.com")
         assert res.status_code == 200

--- a/tests/test_jitter.py
+++ b/tests/test_jitter.py
@@ -10,7 +10,7 @@ import httpx
 import pytest
 import respx
 
-from httpx_retry import AsyncHTTPRetryTransport, HTTPRetryTransport, RetryPolicy
+from httpx_retry import AsyncRetryTransport, RetryPolicy, RetryTransport
 
 
 def exponential_jitter_delay(
@@ -32,7 +32,7 @@ def test_exponential_backoff_with_jitter(respx_mock: respx.MockRouter):
         RetryPolicy().with_attempts(3).with_delay_func(exponential_jitter_delay(0.1, 2))
     )
 
-    with httpx.Client(transport=HTTPRetryTransport(policy=jitter_retry)) as client:
+    with httpx.Client(transport=RetryTransport(policy=jitter_retry)) as client:
         res = client.get("https://example.com")
         assert res.status_code == 200
 
@@ -54,7 +54,7 @@ async def test_async_exponential_backoff_with_jitter(respx_mock: respx.MockRoute
     )
 
     async with httpx.AsyncClient(
-        transport=AsyncHTTPRetryTransport(policy=jitter_retry)
+        transport=AsyncRetryTransport(policy=jitter_retry)
     ) as client:
         res = await client.get("https://example.com")
         assert res.status_code == 200

--- a/tests/test_linear_backoff.py
+++ b/tests/test_linear_backoff.py
@@ -10,7 +10,7 @@ import httpx
 import pytest
 import respx
 
-from httpx_retry import AsyncHTTPRetryTransport, HTTPRetryTransport, RetryPolicy
+from httpx_retry import AsyncRetryTransport, RetryPolicy, RetryTransport
 
 
 def linear_delay(initial_delay: float, increment: float) -> Callable[[int], float]:
@@ -29,7 +29,7 @@ def test_linear_backoff(respx_mock: respx.MockRouter):
     linear_retry = RetryPolicy().with_attempts(3).with_delay(linear_delay(0.1, 0.1))
 
     start = time.monotonic()
-    with httpx.Client(transport=HTTPRetryTransport(policy=linear_retry)) as client:
+    with httpx.Client(transport=RetryTransport(policy=linear_retry)) as client:
         res = client.get("https://example.com")
         assert res.status_code == 200
     end = time.monotonic()
@@ -54,7 +54,7 @@ async def test_async_linear_backoff(respx_mock: respx.MockRouter):
 
     start = time.monotonic()
     async with httpx.AsyncClient(
-        transport=AsyncHTTPRetryTransport(policy=linear_retry)
+        transport=AsyncRetryTransport(policy=linear_retry)
     ) as client:
         res = await client.get("https://example.com")
         assert res.status_code == 200


### PR DESCRIPTION
Closes [#3: (feat) pass custom transports to be wrapped (instead of default ones)](https://github.com/mharrisb1/httpx-retry/issues/3)
