### PR TITLE
Support httpx versions > 0.27

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ packages = [{ include = "httpx_retry", from = "src" }]
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-httpx = "^0.27.0"
+httpx = ">=0.27.0,<1.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^1.11.0"


### PR DESCRIPTION
This would allow newer versions of httpx up until 1.0.

Right now I cannot use this lib with httpx 0.28