### PR TITLE
fix: RetryPolicy can handle zero retries 

### DIFF
--- a/src/httpx_retry/policies/__init__.py
+++ b/src/httpx_retry/policies/__init__.py
@@ -22,23 +22,23 @@ class AdapativePolicyFn(Protocol[PolicyT]):
 class RetryPolicy(BaseRetryPolicy):
     def __init__(
         self,
-        attempts: Optional[int] = None,
-        initial_delay: Optional[float] = None,
+        attempts: int = 1,
+        initial_delay: float = 0.0,
         max_delay: Optional[float] = None,
         delay_func: Optional[Callable[[int], float]] = None,
         timeout: Optional[float] = None,
-        multiplier: Optional[float] = None,
-        retry_on: Optional[Union[list[int], Callable[[int], bool]]] = None,
+        multiplier: float = 1.0,
+        retry_on: Optional[Union[list[int], Callable[[int], bool]]] = (lambda code: code >= 400),
         adaptive_func: Optional[AdapativePolicyFn["RetryPolicy"]] = None,
         adaptive_delay: Optional[float] = None,
     ) -> None:
-        self._attempts = attempts or 1
-        self._initial_delay = initial_delay or 0.0
+        self._attempts = attempts
+        self._initial_delay = initial_delay
         self._max_delay = max_delay
         self._delay_func = delay_func
         self._timeout = timeout
-        self._multiplier = multiplier or 1.0
-        self._retry_on = retry_on or (lambda code: code >= 400)
+        self._multiplier = multiplier
+        self._retry_on = retry_on
         self._adaptive_func = adaptive_func
         self._adaptive_delay = adaptive_delay
 

--- a/tests/test_retry_policy.py
+++ b/tests/test_retry_policy.py
@@ -1,0 +1,16 @@
+import pytest
+
+from httpx_retry import RetryPolicy
+
+
+@pytest.mark.asyncio()
+async def test_retry_policy_can_handle_no_retries():
+    policy = RetryPolicy(attempts=0)
+    assert not policy.should_retry(attempt=0)
+
+
+@pytest.mark.asyncio()
+async def test_retry_policy_make_1_retry_attempt_if_attempts_not_specified():
+    policy = RetryPolicy()
+    assert policy.should_retry(attempt=0, exception=Exception())
+    assert not policy.should_retry(attempt=1, exception=Exception())


### PR DESCRIPTION
https://github.com/mharrisb1/httpx-retry/issues/5

Set default values for `__init__` in RetryPolicy.