### PR TITLE
fix: RetryExecutor attempts starts from zero

### DIFF
--- a/src/httpx_retry/executor.py
+++ b/src/httpx_retry/executor.py
@@ -15,7 +15,7 @@ class RetryExecutor:
     def execute(
         self, func: Callable[..., Response], *args: Any, **kwargs: Any
     ) -> Response:
-        attempt = 1
+        attempt = 0
         start_time = time.monotonic()
         last_exception: Optional[Exception] = None
 

--- a/tests/test_fibonacci_backoff.py
+++ b/tests/test_fibonacci_backoff.py
@@ -29,6 +29,7 @@ def test_fibonacci_backoff(respx_mock: respx.MockRouter):
     route.side_effect = [
         httpx.Response(500),
         httpx.Response(500),
+        httpx.Response(500),
         httpx.Response(200),
     ]
 
@@ -43,7 +44,7 @@ def test_fibonacci_backoff(respx_mock: respx.MockRouter):
     elapsed = end - start
     assert elapsed >= 0.2
 
-    assert route.call_count == 3
+    assert route.call_count == 4
 
 
 @pytest.mark.asyncio()

--- a/tests/test_fixed_delay.py
+++ b/tests/test_fixed_delay.py
@@ -28,6 +28,22 @@ def test_fixed_delay(respx_mock: respx.MockRouter):
     assert route.call_count == 3
 
 
+@respx.mock()
+def test_fixed_delay_only_last_retry_succeed(respx_mock: respx.MockRouter):
+    route = respx_mock.get("https://example.com")
+    route.side_effect = [
+        httpx.Response(500),
+        httpx.Response(500),
+        httpx.Response(200),
+    ]
+
+    immediate_retry = RetryPolicy().with_max_retries(2).with_delay(0.5)
+    with httpx.Client(transport=RetryTransport(policy=immediate_retry)) as client:
+        res = client.get("https://example.com")
+        assert res.status_code == 200
+    assert route.call_count == 3
+
+
 @pytest.mark.asyncio()
 @respx.mock()
 async def test_async_fixed_delay(respx_mock: respx.MockRouter):

--- a/tests/test_fixed_delay.py
+++ b/tests/test_fixed_delay.py
@@ -10,8 +10,9 @@ import respx
 from httpx_retry import AsyncRetryTransport, RetryPolicy, RetryTransport
 
 
+@pytest.mark.parametrize("max_retries", [2, 3])
 @respx.mock()
-def test_fixed_delay(respx_mock: respx.MockRouter):
+def test_fixed_delay(respx_mock: respx.MockRouter, max_retries: int):
     route = respx_mock.get("https://example.com")
     route.side_effect = [
         httpx.Response(500),
@@ -19,28 +20,12 @@ def test_fixed_delay(respx_mock: respx.MockRouter):
         httpx.Response(200),
     ]
 
-    immediate_retry = RetryPolicy().with_max_retries(3).with_delay(0.5)
+    immediate_retry = RetryPolicy().with_max_retries(max_retries).with_delay(0.5)
 
     with httpx.Client(transport=RetryTransport(policy=immediate_retry)) as client:
         res = client.get("https://example.com")
         assert res.status_code == 200
 
-    assert route.call_count == 3
-
-
-@respx.mock()
-def test_fixed_delay_only_last_retry_succeed(respx_mock: respx.MockRouter):
-    route = respx_mock.get("https://example.com")
-    route.side_effect = [
-        httpx.Response(500),
-        httpx.Response(500),
-        httpx.Response(200),
-    ]
-
-    immediate_retry = RetryPolicy().with_max_retries(2).with_delay(0.5)
-    with httpx.Client(transport=RetryTransport(policy=immediate_retry)) as client:
-        res = client.get("https://example.com")
-        assert res.status_code == 200
     assert route.call_count == 3
 
 


### PR DESCRIPTION
https://github.com/mharrisb1/httpx-retry/issues/9

I would consider rewriting RetryExecutor and AsyncRetryExecutor to reduce code duplication.